### PR TITLE
Fix font stacks with sprite fonts only and line breaks getting ignored in scribble_basic_make()

### DIFF
--- a/scripts/scribble_basic_make/scribble_basic_make.gml
+++ b/scripts/scribble_basic_make/scribble_basic_make.gml
@@ -25,7 +25,7 @@ for( var _pos = 1; _pos <= _length; _pos++ ) {
     
     var _char = string_copy( _string, _pos, 1 );
     
-    if ( ord( _char ) == 10 ) {
+    if ( ord( _char ) == 10 || ord( _char ) == 13) {
         _line++;
         _x = 0;
         _y += _line_height;

--- a/scripts/scribble_load_fonts/scribble_load_fonts.gml
+++ b/scripts/scribble_load_fonts/scribble_load_fonts.gml
@@ -109,9 +109,7 @@ if ( _max_width > 0 ) && ( _max_height > 0 ) {
 
 
 
-var _texture = sprite_get_texture( _surface_sprite, 0 );
-var _texture_tw = texture_get_texel_width(  _texture );
-var _texture_th = texture_get_texel_height( _texture );
+
 
 for( var _font = 0; _font < _font_count; _font++ ) {
     
@@ -211,6 +209,10 @@ for( var _font = 0; _font < _font_count; _font++ ) {
     } else {
         
         #region Font
+        
+        var _texture = sprite_get_texture( _surface_sprite, 0 );
+        var _texture_tw = texture_get_texel_width(  _texture );
+        var _texture_th = texture_get_texel_height( _texture );
         
         global.__scribble_image_map[? _name ] = _surface_sprite;
         


### PR DESCRIPTION
This PR fixes two things.  

First of all, when using `scribble_basic_draw_cached()`, line breaks would not get displayed.
Breaking the problem down, it looks like `scribble_basic_make()` uses `__scribble_replace_newlines()` to set all line breaks to `chr(13)`, but `scribble_basic_make()` seems to only test for `chr(10)` (line 26). Behaviour seems to be corrected by checking for `chr(13)`, too.

---

The second commit fixes an error in `scribble_load_fonts()`. It would fail to execute if the `SCRIBBLE_FONT_ARRAY` consisted only of sprite fonts. The local variable `_surface_sprite` gets created in line 105 only if `_max_width` and `_max_height` are set, which only occurs if at least one asset in the font stack is not of type `asset_sprite`, see line 27.  
Since the resulting local variables `_texture`, `_texture_tw` and `texture_th` are only used in the following `for`-statement if the `asset_type` is, again, not a sprite (line 213 and onwards, the pull request prevents the illegal access of the undefined variable `_surface_sprite`.  

Error shown is:
```gml
local variable _surface_sprite(100021, -2147483648) not set before reading it.
 at gml_Script_scribble_load_fonts (line 112) -         var _texture = sprite_get_texture( _surface_sprite, 0 );
```
with my variable setup
```gml
#macro SCRIBBLE_FONT_ARRAY [ [ "sprTbyFontMain", undefined, 0 ], ["sprTbyFontSmall", "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789,.-;:_+-*/|#", 0] ]
```